### PR TITLE
OFFLINE STOP, fix warn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 asd
+node_modules
+package-lock.json

--- a/scripts/commands/staffCommands.js
+++ b/scripts/commands/staffCommands.js
@@ -272,13 +272,14 @@ const registerCommands = (clientCommands, serverCommands, runner) => {
         realP.sendMessage('[scarlet]⚠ [yellow]You do not have access to this command.');
         return;
       }
-      let possiblePlayers = admins.searchNames(args[0]);
-      if(possiblePlayers.length > 20){
-        let exactPlayers = possiblePlayers.select(pdata => pdata.lastName == args[0]);
+      let possiblePlayers = admins.searchNames(args[0]).toSeq();
+      if(possiblePlayers.size > 20){
+        let exactPlayers = admins.findByName(args[0]).toSeq();
         if(exactPlayers.length > 0){
           possiblePlayers = exactPlayers;
         } else {
-          realP.sendMessage('[scarlet]⚠ [yellow]Too many players with that name.');
+          realP.sendMessage('[scarlet]⚠ [yellow]Too many players with that name, be more specific.');
+          return;
         }
       }
 

--- a/scripts/commands/staffCommands.js
+++ b/scripts/commands/staffCommands.js
@@ -292,7 +292,7 @@ const registerCommands = (clientCommands, serverCommands, runner) => {
       let arrayIndex = 0;
       possiblePlayers.forEach(pData => {
         
-        menus.menuStuff.playerList.push(pData.id);
+        menus.menuStuff.playerList.push(pData);
         menus.menuStuff.lastOptionIndex += 1;
         if (options[arrayIndex].length >= 2) {
           arrayIndex += 1;

--- a/scripts/commands/staffCommands.js
+++ b/scripts/commands/staffCommands.js
@@ -256,6 +256,59 @@ const registerCommands = (clientCommands, serverCommands, runner) => {
     })
   );
 
+  clientCommands.register(
+    'stop_offline',
+    '<name>',
+    'Stops an offline player.',
+    runner((args, realP) => {
+      const p = players.getP(realP);
+      const admins = Vars.netServer.admins;
+
+      if (p.fakeAdmin) {
+        return;
+      }
+
+      if (!p.mod && !p.admin) {
+        realP.sendMessage('[scarlet]⚠ [yellow]You do not have access to this command.');
+        return;
+      }
+      let possiblePlayers = admins.searchNames(args[0]);
+      if(possiblePlayers.length > 20){
+        let exactPlayers = possiblePlayers.select(pdata => pdata.lastName == args[0]);
+        if(exactPlayers.length > 0){
+          possiblePlayers = exactPlayers;
+        } else {
+          realP.sendMessage('[scarlet]⚠ [yellow]Too many players with that name.');
+        }
+      }
+
+      menus.menuStuff.playerList = [];
+      menus.menuStuff.lastOptionIndex = 0;
+
+      const title = 'Stop';
+      const message = 'Choose a player to stop.';
+      let options = [[]];
+      let arrayIndex = 0;
+      possiblePlayers.forEach(pData => {
+        
+        menus.menuStuff.playerList.push(pData.id);
+        menus.menuStuff.lastOptionIndex += 1;
+        if (options[arrayIndex].length >= 2) {
+          arrayIndex += 1;
+          options[arrayIndex] = [pData.lastName];
+        } else {
+          options[arrayIndex].push(pData.lastName);
+        }
+      });
+
+      if (options[0].length === 0) options = [];
+
+      options.push(['cancel']);
+
+      Call.menu(realP.con, menus.menuStuff.listeners.stopOffline, title, message, options);
+    })
+  );
+
   // Free
   clientCommands.register(
     'free',

--- a/scripts/commands/staffCommands.js
+++ b/scripts/commands/staffCommands.js
@@ -67,18 +67,18 @@ const registerCommands = (clientCommands, serverCommands, runner) => {
 
       const tp = players.getP(targetPlr);
 
-      if (tp.admin || tp.mod) {
-        realP.sendMessage('[scarlet]⚠ [yellow] You cannot warn staff.');
-        return;
-      }
+      // if (!p.admin && tp.mod) {
+      //   realP.sendMessage('[scarlet]⚠ [yellow] You cannot warn staff.');
+      //   return;
+      // }
 
       const title = 'Warning';
       const message = reason
         ? reason
         : "You have been warned. I suggest you stop what you're doing";
-      let options = [['accept']];
+      let options = [['Ok']];
 
-      Call.menu(targetPlr.con, menus.getMenus().listeners.warn, title, message, options);
+      Call.menu(targetPlr.con, menus.getMenus().warn, title, message, options);
     })
   );
 

--- a/scripts/menus.js
+++ b/scripts/menus.js
@@ -41,16 +41,17 @@ const stopOfflineListener = (player, option) => {
     return;
   }
 
-  const uuid = menuStuff.playerList[option];
-  stopped.addStopped(uuid);
-  players.addPlayerHistory(uuid, {
+  const info = menuStuff.playerList[option];
+  const fishP = players.getPlayerByInfo(info);
+  fishP.stopped = true;
+  stopped.addStopped(info.id);
+  players.addPlayerHistory(info.id, {
     action: 'stopped',
     by: player.name,
     time: Date.now(),
   });
-  player.sendMessage('[#48e076]Selected player was stopped.');
-  //Do NOT send the uuid in the messge.
-  return;
+  player.sendMessage(info.lastName + ' [#48e076] was stopped.');
+  menuStuff.playerList = [];
 };
 
 // free

--- a/scripts/players.js
+++ b/scripts/players.js
@@ -20,6 +20,22 @@ const createPlayer = (player) => {
   return;
 };
 
+/**Gets/creates a FishPlayer from stored playerInfo */
+const getPlayerByInfo = (playerInfo) => {
+  return players[playerInfo.id] ? players[playerInfo.id] :players[playerInfo.id] = {
+    name: playerInfo.lastName,
+    muted: false,
+    mod: false,
+    admin: false,
+    watch: false,
+    member: false,
+    pet: '',
+    highlight: null,
+    history: [],
+    fakeAdmin: false,
+  };
+};
+
 /**
  * Saves only staff and members locally so they persist after restart.
  * Saving all players would cause the object to be too large for
@@ -167,6 +183,7 @@ module.exports = {
   setName: setName,
   addPlayerHistory: addPlayerHistory,
   getP: getP,
+  getPlayerByInfo: getPlayerByInfo,
   stop: stop,
   free: free,
   getAllIds: getAllIds,


### PR DESCRIPTION
Fixes /warn, adds /stop_offline to stop an offline player (must be on the same server as the player was on)
Somewhat tested, but as the stopped api is ip whitelisted im not sure if it worked, but it did send the request

![image](https://user-images.githubusercontent.com/71201189/224293142-96c862c9-b6f7-4e2d-84d6-1b380c5b8401.png)
![image](https://user-images.githubusercontent.com/71201189/224293153-9af664d8-b881-4cc0-b421-b1a18feec376.png)
